### PR TITLE
add str::split_for_each functor callback

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,7 +36,8 @@ https://github.com/jbaldwin/libchain
         using namespace chain;
 
         auto print_parts = [](auto& parts) {
-            for(const auto& part : parts) {
+            for (const auto& part : parts)
+            {
                 std::cout << part << " ";
             }
             std::cout << "\n";
@@ -49,10 +50,9 @@ https://github.com/jbaldwin/libchain
         print_parts(parts1);
 
         // A split mapped into integers.
-        auto parts2 = str::split_map<int64_t>("1,2,3", ',', [](std::string_view part) {
-            return str::to_number<int64_t>(part).value_or(0);
-        });
-        /// parts2 = { 1, 2, 3 }
+        auto parts2 = str::split_map<int64_t>(
+            "1,2,3", ',', [](std::string_view part) { return str::to_number<int64_t>(part).value_or(0); });
+        // parts2 = { 1, 2, 3 }
         print_parts(parts2);
 
         // A pre-allocated split, for large splits to reduce allocations.
@@ -62,15 +62,23 @@ https://github.com/jbaldwin/libchain
         // parts3 = { "1", "2", "3", ... , "128" }
         print_parts(parts3);
 
+        // A split with zero allocations.
+        str::split_for_each("1,2,3,4,5", ',', [](std::string_view part) -> bool {
+            // 1, 2, 3, 4, 5
+            std::cout << part << ", ";
+            return true; // Continue parsing, return false to stop at any time.
+        });
+        std::cout << "\n";
+
         // A simple csv join.
-        std::vector<int64_t> parts4{1,2,3};
-        auto joined1 = str::join(parts4, ',');
+        std::vector<int64_t> parts4{1, 2, 3};
+        auto                 joined1 = str::join(parts4, ',');
         // joined1 == "1,2,3"
         std::cout << joined1 << "\n";
 
         // A map join which squares its parts first.
-        std::vector<int64_t> parts5{1,2,3};
-        auto joined2 = str::map_join(parts5, ',', [](int64_t x) { return x * x; });
+        std::vector<int64_t> parts5{1, 2, 3};
+        auto                 joined2 = str::map_join(parts5, ',', [](int64_t x) { return x * x; });
         // joined2 == "1,4,9"
         std::cout << joined2 << "\n";
 

--- a/examples/readme.cpp
+++ b/examples/readme.cpp
@@ -23,7 +23,7 @@ int main()
     // A split mapped into integers.
     auto parts2 = str::split_map<int64_t>(
         "1,2,3", ',', [](std::string_view part) { return str::to_number<int64_t>(part).value_or(0); });
-    /// parts2 = { 1, 2, 3 }
+    // parts2 = { 1, 2, 3 }
     print_parts(parts2);
 
     // A pre-allocated split, for large splits to reduce allocations.
@@ -32,6 +32,14 @@ int main()
     str::split("1,2,3,...,128", ',', parts3);
     // parts3 = { "1", "2", "3", ... , "128" }
     print_parts(parts3);
+
+    // A split with zero allocations.
+    str::split_for_each("1,2,3,4,5", ',', [](std::string_view part) -> bool {
+        // 1, 2, 3, 4, 5
+        std::cout << part << ", ";
+        return true; // Continue parsing, return false to stop at any time.
+    });
+    std::cout << "\n";
 
     // A simple csv join.
     std::vector<int64_t> parts4{1, 2, 3};

--- a/inc/chain/chain.hpp
+++ b/inc/chain/chain.hpp
@@ -302,9 +302,10 @@ auto split_map(std::string_view data, char delim, const map_functor_type& map) -
  * @tparam functor_type std::invocable<void(std::string_view)>
  * @param data The string data to split by the given delimeter.
  * @param delim The delimeter to split the data by.
- * @param functor The functor to call for each tokenized part of the data.
+ * @param functor The functor to call for each tokenized part of the data.  Return true to continue
+ *                parsing more token parts, return false to stop parsing.
  */
-template<case_t case_type = case_t::sensitive, typename functor_type = std::function<void(std::string_view)>>
+template<case_t case_type = case_t::sensitive, typename functor_type = std::function<bool(std::string_view)>>
 auto split_for_each(std::string_view data, std::string_view delim, functor_type&& functor) -> void
 {
     std::size_t length;
@@ -324,14 +325,19 @@ auto split_for_each(std::string_view data, std::string_view delim, functor_type&
 
         // The length of this split is from start to next.
         length = next - start;
-        functor(std::string_view{data.data() + start, length});
+
+        // Call the users functor for this token part, if they return false stop parsing.
+        if(!functor(std::string_view{data.data() + start, length}))
+        {
+            break;
+        }
 
         // Update our iteration to skip the 'next' delimiter found.
         start = next + delim.length();
     }
 }
 
-template<case_t case_type = case_t::sensitive, typename functor_type = std::function<void(std::string_view)>>
+template<case_t case_type = case_t::sensitive, typename functor_type = std::function<bool(std::string_view)>>
 auto split_for_each(std::string_view data, char delim, functor_type&& functor) -> void
 {
     split_for_each<case_type, functor_type>(data, std::string_view{&delim, 1}, std::forward<functor_type>(functor));

--- a/test/test_split.cpp
+++ b/test/test_split.cpp
@@ -108,3 +108,49 @@ TEST_CASE("split_map csv to int")
     REQUIRE(parts[1] == 2);
     REQUIRE(parts[2] == 3);
 }
+
+TEST_CASE("split_for_each char empty string")
+{
+    uint64_t called{0};
+    chain::str::split_for_each("", '\n', [&](std::string_view) {
+        ++called;
+    });
+
+    REQUIRE(called == 1);
+}
+
+TEST_CASE("split_for_each string_view empty string")
+{
+    uint64_t called{0};
+    chain::str::split_for_each("", "\n", [&](std::string_view) {
+        ++called;
+    });
+
+    REQUIRE(called == 1);
+}
+
+TEST_CASE("split_for_each csv")
+{
+    uint64_t called{0};
+    chain::str::split_for_each("1,2,3333,4", ",", [&](std::string_view s) {
+        ++called;
+
+        switch(called)
+        {
+            case 1:
+                REQUIRE(s == "1");
+                break;
+            case 2:
+                REQUIRE(s == "2");
+                break;
+            case 3:
+                REQUIRE(s == "3333");
+                break;
+            case 4:
+                REQUIRE(s == "4");
+                break;
+        }
+    });
+
+    REQUIRE(called == 4);
+}

--- a/test/test_split.cpp
+++ b/test/test_split.cpp
@@ -114,6 +114,7 @@ TEST_CASE("split_for_each char empty string")
     uint64_t called{0};
     chain::str::split_for_each("", '\n', [&](std::string_view) {
         ++called;
+        return true;
     });
 
     REQUIRE(called == 1);
@@ -124,6 +125,7 @@ TEST_CASE("split_for_each string_view empty string")
     uint64_t called{0};
     chain::str::split_for_each("", "\n", [&](std::string_view) {
         ++called;
+        return true;
     });
 
     REQUIRE(called == 1);
@@ -132,7 +134,7 @@ TEST_CASE("split_for_each string_view empty string")
 TEST_CASE("split_for_each csv")
 {
     uint64_t called{0};
-    chain::str::split_for_each("1,2,3333,4", ",", [&](std::string_view s) {
+    chain::str::split_for_each("1,2,3333,4", ",", [&](std::string_view s) -> bool {
         ++called;
 
         switch(called)
@@ -150,7 +152,26 @@ TEST_CASE("split_for_each csv")
                 REQUIRE(s == "4");
                 break;
         }
+
+        return true;
     });
 
     REQUIRE(called == 4);
+}
+
+TEST_CASE("split_for_each stop early")
+{
+    uint64_t called{0};
+    chain::str::split_for_each("1,2,3,4,5,6,7,8,9,10", ",", [&](std::string_view s) -> bool {
+        ++called;
+
+        if(called >= 3)
+        {
+            return false;
+        }
+
+        return true;
+    });
+
+    REQUIRE(called == 3);
 }


### PR DESCRIPTION
This function will no require the overhead to allocate
a vector to store the string_views and instead calls
a functor for each tokenized part of the split string